### PR TITLE
Add 'forestCode' attribute back into forests.es6

### DIFF
--- a/server/src/controllers/forests/forests.es6
+++ b/server/src/controllers/forests/forests.es6
@@ -17,7 +17,7 @@ const fsForests = {};
 fsForests.getForests = (req, res) => {
   forestsDb.fsForests
     .findAll({
-      attributes: ['id', 'forestName', 'forestNameShort', 'forestUrl', 'description', 'forestAbbr', 'startDate', 'endDate',
+      attributes: ['id', 'forestName', 'forestCode', 'forestNameShort', 'forestUrl', 'description', 'forestAbbr', 'startDate', 'endDate',
         'contact', 'mapLinks', 'woodCost', 'state', 'stateFips', 'region',
         'permitType', 'minCords', 'maxCords', 'districts'],
 

--- a/server/src/controllers/forests/forests.es6
+++ b/server/src/controllers/forests/forests.es6
@@ -17,9 +17,9 @@ const fsForests = {};
 fsForests.getForests = (req, res) => {
   forestsDb.fsForests
     .findAll({
-      attributes: ['id', 'forestName', 'forestCode', 'forestNameShort', 'forestUrl', 'description', 'forestAbbr', 'startDate', 'endDate',
-        'contact', 'mapLinks', 'woodCost', 'state', 'stateFips', 'region',
-        'permitType', 'minCords', 'maxCords', 'districts'],
+      attributes: ['id', 'forestName', 'forestCode', 'forestNameShort', 'forestUrl', 'description',
+        'forestAbbr', 'startDate', 'endDate', 'contact', 'mapLinks', 'woodCost', 'state',
+        'stateFips', 'region', 'permitType', 'minCords', 'maxCords', 'districts'],
 
       order: [['id', 'ASC']]
     })


### PR DESCRIPTION
﻿## Summary
Addresses Issue # [225](https://app.zenhub.com/workspaces/open-forest-58f8bbe105a35fad2d275a0c/issues/usdaforestservice/usfs-timber-permitting/225)

Address card 225 by adding the `'forestCode'` attribute back into the `forests.es6` file.

## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] All tests are passing.
- [x] This code has been reviewed by someone other than the original author
