### PR TITLE
 login.gov for firewood

### DIFF
--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -107,7 +107,6 @@ const appRoutes: Routes = [
       title: 'US Forest Service Open Forest',
       breadcrumbs: true,
       text: 'Mt. Baker-Snoqualmie special use permits',
-      displayLogin: true,
       specialUse: true,
     },
     resolve: {
@@ -358,10 +357,16 @@ const appRoutes: Routes = [
           },
           {
             path: 'buy',
-            data: { breadcrumbs: 'Buy a permit' },
+            canActivateChild: [AccessControlService],
+            data: {
+              breadcrumbs: 'Buy a permit',
+             },
             children: [
               {
                 path: '',
+                data: {
+                  displayLogin: true
+                },
                 component: BuyFirewoodPermitComponent
               }
             ]

--- a/frontend/src/app/app-routing.module.ts
+++ b/frontend/src/app/app-routing.module.ts
@@ -107,6 +107,7 @@ const appRoutes: Routes = [
       title: 'US Forest Service Open Forest',
       breadcrumbs: true,
       text: 'Mt. Baker-Snoqualmie special use permits',
+      displayLogin: true,
       specialUse: true,
     },
     resolve: {

--- a/frontend/src/app/firewood/forests/firewood-guidelines/firewood-guidelines.component.html
+++ b/frontend/src/app/firewood/forests/firewood-guidelines/firewood-guidelines.component.html
@@ -26,7 +26,7 @@
       <p>Firewood permits are <strong>${{forest.woodCost}} per cord</strong> with a <strong>{{forest.minCords}} cord (${{minCost()}}) minimum purchase. </strong>Limit of 12 cords per household per year. All permits are nonrefundable.
       <h3>Buy a permit</h3>
       <p>You can buy firewood permits online or in-person at one of <a href="#prohibited">our district offices</a>.</p>
-      <button #staticBuyButton [routerLink]="['/firewood/forests/', forest.forestAbbr, 'buy']" class="usa-button margin-top-1" id="static-buy-permit-link" tabIndex="-1">Buy permit</button>
+      <app-button routerLink="/firewood/forests/{{forest.forestAbbr}}/buy" firewood="true"></app-button>
 
       <!-- where to find firewood -->
       <app-where-to-find></app-where-to-find>

--- a/frontend/src/app/shared/button/app-button.component.html
+++ b/frontend/src/app/shared/button/app-button.component.html
@@ -1,4 +1,4 @@
-<a *ngIf="!btnAlt && !learnMore" class="usa-button-inverse usa-button usa-button-big" [routerLink]="link">
+<a *ngIf="!btnAlt && !learnMore && !firewood" class="usa-button-inverse usa-button usa-button-big" [routerLink]="link">
   {{buttonText}}
   <span *ngIf="!authentication.user"  class="button-hint usa-form-hint">Sign in with <img src="/assets/img/site-wide/login.gov-logo.svg" alt="login.gov" class="login-gov" role="img" />  to apply
   </span>
@@ -10,6 +10,14 @@
     {{buttonText}}
   <span *ngIf="authentication.user"  class="button-hint usa-form-hint">Apply</span>
   <span *ngIf="!authentication.user" class="button-hint usa-form-hint">Sign in with <br><img src="/assets/img/site-wide/login.gov-logo.svg" alt="login.gov" class="login-gov" role="img" />  <br>to apply</span>
+  </a>
+</div>
+
+<div *ngIf="firewood">
+  <a class="usa-button-primary-alt usa-button usa-button display-inline" [routerLink]="link" (click)="setRequestingUrl()">
+    {{buttonText}}
+  <span *ngIf="authentication.user"  class="button-hint usa-form-hint">Buy Permit</span>
+  <span *ngIf="!authentication.user" class="button-hint usa-form-hint">Sign in with <br><img src="/assets/img/site-wide/login.gov-logo.svg" alt="login.gov" class="login-gov" role="img" />  <br>to purchase</span>
   </a>
 </div>
 

--- a/frontend/src/app/shared/button/app-button.component.ts
+++ b/frontend/src/app/shared/button/app-button.component.ts
@@ -10,6 +10,7 @@ export class AppButtonComponent {
   @Input() buttonText: string;
   @Input() btnAlt: false;
   @Input() learnMore: false;
+  @Input() firewood: false;
 
   constructor(public authentication: AuthenticationService) {}
 


### PR DESCRIPTION
﻿## Summary
Addresses Issue Login.gov for firewood

Please note if fully resolves the issue per the acceptance criteria: Yes

*This Pull request updates the firewood buy route to be protected by our access control service implementing login.gov. Locally it hits the mock auth route, we need to test in DEV for full login.gov implementation*

## Impacted Areas of the Site
- /firewood/forests/{{forest.forest.Abbr}}/buy


## This pull request changes...
- [ ] Route protections on firewood

## This pull request is ready to merge when...
- [ ] Feature branch is starts with the issue number
- [ ] Is connected to its original issue via zenhub 👇
- [ ] Tests have been updated 
- [ ] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Jenkins)
- [ ] This code has been reviewed by someone other than the original author
