### PR TITLE
1575 warning banner user sesh time limit

### DIFF
--- a/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.html
+++ b/frontend/src/app/application-forms/application-noncommercial-group/application-noncommercial-group.component.html
@@ -26,6 +26,14 @@
             <li>Once your application is approved, you will receive your permit within 2 weeks. If your application is not approved, you will be notified via email.</li>
           </ol>
         </div>
+        <div class="usa-alert usa-alert-info usa-alert-paragraph">
+          <div class="usa-alert-body">
+            <h3 class="usa-alert-heading">This is a timed application</h3>
+            <p class="usa-alert-text">
+              This application will time out after one hour and all progress will be lost if not already submitted.
+            </p>
+          </div>
+        </div>
         <br>
         <p class="form-directions">required fields<span class="required-fields-asterisk">*</span></p>
         <div id="form-errors" *ngIf="(submitted && !applicationForm.valid) || dateStatus.hasErrors" class="usa-alert usa-alert-error" aria-live="assertive" aria-hidden="false" role="alert">

--- a/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.html
+++ b/frontend/src/app/application-forms/temporary-outfitters/temporary-outfitters.component.html
@@ -16,6 +16,14 @@
         </p>
         <p *ngIf="applicationFieldsService.getEditApplication()">You are about to update your permit application. Once you click "Save Edits & Submit" you will not be able to make any further updates unless your application is placed on hold again.
         </p>
+        <div class="usa-alert usa-alert-info usa-alert-paragraph">
+          <div class="usa-alert-body">
+            <h3 class="usa-alert-heading">This is a timed application</h3>
+            <p class="usa-alert-text">
+              This application will time out after one hour and all progress will be lost if not already submitted.
+            </p>
+          </div>
+        </div>
         <br>
         <p class="form-directions">required fields <span class="required-fields-asterisk">*</span></p>
         <div id="form-errors"


### PR DESCRIPTION
﻿## Summary
Addresses Issue #1576 
https://app.zenhub.com/workspaces/open-forest-58f8bbe105a35fad2d275a0c/issues/usdaforestservice/fs-open-forest-platform/1575

This PR adds warning banners to both Special-Use applications pages to inform the user that there is a time-limit to their user-session and progress will be lost if not submitted within an hour.


## This pull request is ready to merge when...
- [x] Feature branch is starts with the issue number
- [x] Is connected to its original issue via zenhub 👇
- [x] Tests have been updated 
- [x] All tests are passing and meet coverage, linting, and accessibility requirements. And no security vulnerabilities ⚫️(Circle)
- [ ] This code has been reviewed by someone other than the original author
